### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/test/Application/Service/GetRealPathFromNamespaceTest.php
+++ b/test/Application/Service/GetRealPathFromNamespaceTest.php
@@ -22,7 +22,7 @@ class GetRealPathFromNamespaceTest extends TestCase
 
     private GetRealPathFromNamespace $getRealPathFromNamespace;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->getRealPathFromNamespace = new GetRealPathFromNamespace(
             new GetClassNameFromFQCN(self::class),


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/9.3/fixtures.html?highlight=fixtures), it should be `protected function setUp(): void`.