### PR TITLE
Fix namespace and initialize ClearConfigCache test

### DIFF
--- a/test/Application/Command/ClearConfigCacheTest.php
+++ b/test/Application/Command/ClearConfigCacheTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace AntidotTest\DevTools\Application\Command;
+
+use Antidot\DevTools\Application\Command\ClearConfigCache;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ClearConfigCacheTest extends TestCase
+{
+    public function testNoConfigurationPath()
+    {
+        $config = [];
+        $app = new Application('Dev Tools');
+        $app->add(new ClearConfigCache($config));
+
+        $tester = new CommandTester($app->find('config:clear-cache'));
+
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertStringContainsString('No configuration cache path found', $tester->getDisplay());
+    }
+
+    public function testCannotFindConfigCacheFile()
+    {
+        $config = [
+            'config_cache_path' => '/path/not/found',
+            'cli_config_cache_path' => '/path/not/found',
+        ];
+        $app = new Application('Dev Tools');
+        $app->add(new ClearConfigCache($config));
+
+        $tester = new CommandTester($app->find('config:clear-cache'));
+
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertStringContainsString('Configured config cache file \'/path/not/found\' not found', $tester->getDisplay());
+    }
+}

--- a/test/CreateClassFileTest.php
+++ b/test/CreateClassFileTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 
-namespace AntidotTest\DevTools\Application\Service;
+namespace AntidotTest\DevTools;
 
 use Antidot\DevTools\Application\Service\CreateClassFile;
 use org\bovigo\vfs\vfsStream;


### PR DESCRIPTION
# Changed log

- Initialize the `ClearConfigCache` class test
- Fix namespace for `CreateClassFile` class. It should be `AntidotTest\DevTools;`.